### PR TITLE
Fix disapear up and running message after clicking on back btn #49

### DIFF
--- a/src/Mastodon.svelte
+++ b/src/Mastodon.svelte
@@ -212,6 +212,7 @@
               deploying = false;
               success = false;
               error = false;
+              isUp = false;
               if (listener) {
                 listener();
                 listener = undefined;


### PR DESCRIPTION
Related issues 
[#49 - Your mastodon instance is up and running doesn't disappear after you change the page](https://github.com/threefoldtech/www-mastodon/issues/49)