### PR TITLE
Development adding space before deploying message

### DIFF
--- a/src/Mastodon.svelte
+++ b/src/Mastodon.svelte
@@ -172,7 +172,7 @@
       {/if}
     </section>
 
-    <section style:margin-top="40px" class:d-none={!deploying}>
+    <section class:d-none={!deploying}>
       <b-notification
         color={error ? "danger" : success ? "success" : "info"}
         light

--- a/src/Mastodon.svelte
+++ b/src/Mastodon.svelte
@@ -172,7 +172,7 @@
       {/if}
     </section>
 
-    <section class:d-none={!deploying}>
+    <section style:margin-top="40px" class:d-none={!deploying}>
       <b-notification
         color={error ? "danger" : success ? "success" : "info"}
         light

--- a/src/components/Balance.svelte
+++ b/src/components/Balance.svelte
@@ -29,7 +29,7 @@
   }
 </script>
 
-{#if free && locked}
+{#if free != undefined && locked != undefined}
   <div
     class="card"
     style:padding="15px"
@@ -39,12 +39,12 @@
   >
     <p>
       Balance: <span style="font-weight: bold;"
-        >{free ? free.toFixed(3) + " TFT" : "Loading.."}</span
+        >{free.toFixed(3) + " TFT"}</span
       >
     </p>
     <p>
       Locked: <span style="font-weight: bold;"
-        >{locked ? locked.toFixed(3) + " TFT" : "Loading.."}</span
+        >{locked.toFixed(3) + " TFT"}</span
       >
     </p>
     <button

--- a/src/components/Balance.svelte
+++ b/src/components/Balance.svelte
@@ -32,10 +32,11 @@
 {#if free != undefined && locked != undefined}
   <div
     class="card"
-    style:padding="15px"
+    style:padding="10px"
+    style:width="70%"
     style:background="rgb(245 245 245)"
-    style:float="right"
-    style:margin-top="-30px"
+    style:text-align="center"
+
   >
     <p>
       Balance: <span style="font-weight: bold;"

--- a/src/components/PriceCalculator.svelte
+++ b/src/components/PriceCalculator.svelte
@@ -50,26 +50,34 @@
 <div>
   {#if mastodon}
     {#if mastodon$.value.mnemonics.valid}
-      <Balance />
-      {#each [price, price50K] as p, index}
-        <div style:margin-bottom={index === 0 ? -5 : undefined}>
-          <b-tags addons align="centered" size="large">
-            <b-tag>
-              {mastodon$.value.mnemonics.valid && !loading
-                ? "The deployment will cost "
-                : ""}
-              <strong class="mr-1 ml-1">
-                {loading ? "Loading..." : p.toFixed(2)}
-              </strong>
-              {mastodon$.value.mnemonics.valid
-                ? `USD/Month ${
-                    index === 1 ? "with a 50k balance of TFT, after applying discount" : ""
-                  }`
-                : ""}
-            </b-tag>
-          </b-tags>
+      <div class="columns is-vcentered" style:margin-bottom="10px">
+        <div class="column is-10">
+          {#each [price, price50K] as p, index}
+            <div style:margin-bottom={index === 0 ? -5 : undefined}>
+              <b-tags addons align="centered" size="large">
+                <b-tag>
+                  {mastodon$.value.mnemonics.valid && !loading
+                    ? "The deployment will cost "
+                    : ""}
+                  <strong class="mr-1 ml-1">
+                    {loading ? "Loading..." : p.toFixed(2)}
+                  </strong>
+                  {mastodon$.value.mnemonics.valid
+                    ? `USD/Month ${
+                        index === 1 ? "with a 50k balance of TFT, after applying discount" : ""
+                      }`
+                    : ""}
+                </b-tag>
+              </b-tags>
+            </div>
+          {/each}
         </div>
-      {/each}
+        <div class="column" style:display="flex"
+        style:justify-content="end">
+          <Balance />
+        </div>
+
+      </div>
     {/if}
   {/if}
 </div>


### PR DESCRIPTION
Rehandle and improve the UI of user balance, added space after the balance card, and resize the card in different resolutions/window sizes.


![image](https://user-images.githubusercontent.com/57001890/205610548-e2c8df80-8a13-4c6e-af8a-a9f2c58499ae.png)

Related issues 

[#58 - add spacing before the logs box](https://github.com/threefoldtech/www-mastodon/issues/58)
[#61 - UI: User balance blocks part of the description at certain resolutions/window sizes](https://github.com/threefoldtech/www-mastodon/issues/61)
[#62 - Balance Doesn't appear for generated accounts](https://github.com/threefoldtech/www-mastodon/issues/62)
