### PR TITLE
Hide the error message if the mnemonics field is empty and not touched.

### DIFF
--- a/src/tabs/Credentials.svelte
+++ b/src/tabs/Credentials.svelte
@@ -2,18 +2,18 @@
 
 <script lang="ts">
   import type { MastodonForm } from "../Mastodon.svelte";
-  const { Input, btn } = window.tfSvelteBulmaWc;
   import { getGrid, noBalanceMessage, Session } from "../utils";
   import Qrcode from "../components/Qrcode.svelte";
   import type { NetworkEnv } from "grid3_client";
-  import { onMount } from "svelte";
-  import type { FormControl } from "tf-svelte-rx-forms";
-  const { HTTPMessageBusClient } = window.tsRmbHttpClient;
-  const { generateKeyPair } = window.webSshKeygen;
-
+  
   export let show: boolean;
   export let mastodon: MastodonForm;
   // export let loadSSH: boolean;
+
+  const { Input, btn } = window.tfSvelteBulmaWc;
+  const { HTTPMessageBusClient } = window.tsRmbHttpClient;
+  const { generateKeyPair } = window.webSshKeygen;
+
 
   let __init = false;
   $: if (mastodon) {

--- a/src/utils/form.ts
+++ b/src/utils/form.ts
@@ -149,5 +149,12 @@ export const mastodon = fb.group({
 });
 
 const mnemonics = mastodon.get("mnemonics");
-mnemonics.markAsDirty();
-mnemonics.markAsTouched();
+
+mnemonics.subscribe(mn => {
+  if(mn.value.length > 0 && !mnemonics.valid){
+    mnemonics.markAsDirty();
+    mnemonics.markAsTouched();
+  };
+});
+
+

--- a/src/utils/form.ts
+++ b/src/utils/form.ts
@@ -1,6 +1,8 @@
+import type { Unsubscriber } from "tf-svelte-rx-forms/dist/internals/rx_store";
 import { getGrid, getBalance } from ".";
 import { generateString } from "./helpers";
 import { isMnemonics, isValidSSH } from "./validators";
+import { get } from "svelte/store"
 
 const { fb, validators } = window.tfSvelteRxForms;
 
@@ -149,12 +151,12 @@ export const mastodon = fb.group({
 });
 
 const mnemonics = mastodon.get("mnemonics");
-
-mnemonics.subscribe(mn => {
-  if(mn.value.length > 0 && !mnemonics.valid){
+let unsub: Unsubscriber;
+unsub = mnemonics.subscribe(mn => {
+  if (mn.value.length > 0 && !mnemonics.valid) {
+    console.log("im here", unsub);
     mnemonics.markAsDirty();
     mnemonics.markAsTouched();
+    unsub?.();
   };
 });
-
-


### PR DESCRIPTION
Related issues 
[#63 - Mnemonics field validation is activated before the user enters anything](https://github.com/threefoldtech/www-mastodon/issues/63)