### PR TITLE
Show better error message

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     </style>
   </head>
   <body>
-    <tf-mastodon></tf-mastodon>
+    <tf-mastodon provider="1"></tf-mastodon>
     <br />
     <tf-mastodon-list></tf-mastodon-list>
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "decimal.js": "^10.4.2",
     "lodash": "^4.17.21",
     "qrcode": "^1.5.1",
-    "tf-svelte-bulma-wc": "^1.0.7",
+    "tf-svelte-bulma-wc": "^1.0.8",
     "tf-svelte-rx-forms": "^1.0.3",
     "tfgrid-gql": "^1.0.0",
     "ts-rmb-http-client": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash": "^4.17.21",
     "qrcode": "^1.5.1",
     "tf-svelte-bulma-wc": "^1.0.7",
-    "tf-svelte-rx-forms": "^1.0.2",
+    "tf-svelte-rx-forms": "^1.0.3",
     "tfgrid-gql": "^1.0.0",
     "ts-rmb-http-client": "^1.0.7",
     "web-ssh-keygen": "^0.1.2"

--- a/public/config.js
+++ b/public/config.js
@@ -1,3 +1,3 @@
 window.config = {
-  network: "dev",
+  network: "main",
 };

--- a/src/Mastodon.svelte
+++ b/src/Mastodon.svelte
@@ -9,7 +9,6 @@
   import {
     generateString,
     deployVM,
-    checkNode,
     getDomainName,
     deployGateway,
     mastodon,
@@ -42,6 +41,15 @@
   let listener: (() => void) | undefined;
   let isUp: boolean = false;
   async function onDeploy() {
+    if (mastodon.valid) {
+      // Revalidate nodeId to verify that node still up
+      await mastodon.get("nodeId").validate();
+
+      // Trigger validation for any fields of selectNodeID
+      // to verify that node still UP
+      mastodon.get("certified").setValue(mastodon$.value.certified.value);
+    }
+
     if (!mastodon.valid) {
       mastodon.markAsDirty();
       mastodon.markAsTouched();
@@ -86,10 +94,6 @@
 
     try {
       events.addListener("logs", (msg: any) => (message = msg));
-
-      message = `Checking the status of Node(${value.nodeId})`;
-      await checkNode(value.mnemonics, value.nodeId);
-      message = `Node(${value.nodeId}) is online`;
 
       const domainName = await getDomainName(value.mnemonics, value.name);
       const [publicNodeId, nodeDomain] = value.gateway.split(":");

--- a/src/Mastodon.svelte
+++ b/src/Mastodon.svelte
@@ -176,7 +176,12 @@
 
   $: v$ = mastodon$.value;
   $: credentialsHasError = isNotValid(v$.mnemonics, v$.sshKey);
-  $: basicHasError = isNotValid(v$.name, v$.admin.value.email);
+  $: basicHasError = isNotValid(
+    v$.name,
+    v$.admin.value.email,
+    v$.region,
+    v$.certified
+  );
   $: advancedHasError = isNotValid(
     v$.cpu,
     v$.memory,

--- a/src/components/SelectNodeId.svelte
+++ b/src/components/SelectNodeId.svelte
@@ -61,6 +61,13 @@
         nodes = nodes.filter((node) =>
           allowedCountried?.includes(node.location.country)
         );
+
+        if (nodes.length === 0) {
+          const error = `No nodes were found in '${region}' region.`;
+          if (form.get("region").getValue().error !== error) {
+            form.get("region").setValue(region, { error });
+          }
+        }
       }
 
       if (nodes.some((n) => n.nodeId === nodeId)) {

--- a/src/components/SelectNodeId.svelte
+++ b/src/components/SelectNodeId.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
   import type { MastodonForm } from "../Mastodon.svelte";
-  import { findNodes } from "../utils";
+  import { findNodes, getErrorFromCtx } from "../utils";
   const { Select } = window.tfSvelteBulmaWc;
   const { fb, FormGroup, validators } = window.tfSvelteRxForms;
   import debounce from "lodash/debounce.js";
@@ -48,6 +48,11 @@
 
       if (form.get("certified").value) {
         nodes = nodes.filter((node) => node.certificationType === "Certified");
+        if (nodes.length === 0) {
+          const error = "No certified nodes were found.";
+          if (form.get("certified").getValue().error !== error)
+            form.get("certified").setValue(true, { error });
+        }
       }
 
       const region = form.get("region").value;

--- a/src/utils/form.ts
+++ b/src/utils/form.ts
@@ -144,7 +144,7 @@ export const mastodon = fb.group({
     port: [null as number, [validators.isPort("Invalid SMTP port.")]],
   }),
 
-  region: [null as string],
+  region: [null as string, [getErrorFromCtx]],
 
   certified: [false, [getErrorFromCtx]],
 
@@ -162,9 +162,11 @@ unsub = mnemonics.subscribe((mn) => {
 });
 
 export function getErrorFromCtx<T extends FCE>(
-  ctrl: FormControl<T>,
+  _: FormControl<T>,
   ctx?: { error: string }
 ) {
+  console.log({ ctrl: _, ctx });
+
   if (ctx?.error) {
     return { message: ctx.error };
   }

--- a/src/utils/form.ts
+++ b/src/utils/form.ts
@@ -1,4 +1,6 @@
+import type { FormControl } from "tf-svelte-rx-forms";
 import type { Unsubscriber } from "tf-svelte-rx-forms/dist/internals/rx_store";
+import type { FCE } from "tf-svelte-rx-forms/dist/modules/form_control";
 import { getGrid, getBalance } from ".";
 import { generateString } from "./helpers";
 import { isMnemonics, isValidSSH } from "./validators";
@@ -144,17 +146,26 @@ export const mastodon = fb.group({
 
   region: [null as string],
 
-  certified: [false],
+  certified: [false, [getErrorFromCtx]],
 
   tfConnect: [false],
 });
 
 const mnemonics = mastodon.get("mnemonics");
 let unsub: Unsubscriber;
-unsub = mnemonics.subscribe(mn => {
+unsub = mnemonics.subscribe((mn) => {
   if (mn.value.length > 0 && !mnemonics.valid) {
     mnemonics.markAsDirty();
     mnemonics.markAsTouched();
     unsub?.();
-  };
+  }
 });
+
+export function getErrorFromCtx<T extends FCE>(
+  ctrl: FormControl<T>,
+  ctx?: { error: string }
+) {
+  if (ctx?.error) {
+    return { message: ctx.error };
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1262,20 +1262,12 @@ svelte@^3.52.0:
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.53.1.tgz#db9d7df7a8f570e8e22547444c149208b1914442"
   integrity sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw==
 
-tf-svelte-bulma-wc@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/tf-svelte-bulma-wc/-/tf-svelte-bulma-wc-1.0.7.tgz#1d33f672a1da7746365b195a3e93b10c44d5beab"
-  integrity sha512-ueo+UwIXNZxXxGHFce9GCSJnUToK/3pVVFneMOSvsrK2Q1ApPu7EBlo9niFJR4RE15VazUjBb2MlkXUy5Cf5lQ==
+tf-svelte-bulma-wc@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/tf-svelte-bulma-wc/-/tf-svelte-bulma-wc-1.0.8.tgz#593b2038b993c97bac3b5e63669b09f7fd6e6329"
+  integrity sha512-GXV23i9XwQSp2vB0jc7gszreok7EVc0EtVW7oQ4du9HNEjqWmoVKjKg9jbIPsByu1MVf7jEMHH7oJfImHQkyzg==
   dependencies:
-    tf-svelte-rx-forms "^1.0.2"
-
-tf-svelte-rx-forms@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/tf-svelte-rx-forms/-/tf-svelte-rx-forms-1.0.2.tgz#a1352ffdc2d910c198edaf3e75fddee2868135b2"
-  integrity sha512-kq2jfws89lv9OWOvL45lNcaCBegyJCUXRK3I2cr6Vgr5jxL+Im3Z7BAVU4FqfnrJYZ0i4OGEWqaIJ4mcSoDcZA==
-  dependencies:
-    "@types/validator" "^13.7.7"
-    validator "^13.7.0"
+    tf-svelte-rx-forms "^1.0.3"
 
 tf-svelte-rx-forms@^1.0.3:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,6 +1277,14 @@ tf-svelte-rx-forms@^1.0.2:
     "@types/validator" "^13.7.7"
     validator "^13.7.0"
 
+tf-svelte-rx-forms@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tf-svelte-rx-forms/-/tf-svelte-rx-forms-1.0.3.tgz#bec6b320873c86fcfd2c87d8cfe4b414bf055cb9"
+  integrity sha512-TXsxjQ6Zm/2XS9YUGY9QkERyU3TIkDbs1+eY9lG2POutnkQdz7PdIJF5vMroZLupXBOQJUw8nFZysawh//GuSg==
+  dependencies:
+    "@types/validator" "^13.7.7"
+    validator "^13.7.0"
+
 tfgrid-gql@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tfgrid-gql/-/tfgrid-gql-1.0.0.tgz#b5e8cff55be43a1b5ebee8e22e2bd5898ae75a2b"


### PR DESCRIPTION
## Issues
- https://github.com/threefoldtech/www-mastodon/issues/20
- https://github.com/threefoldtech/www-mastodon/issues/73
- https://github.com/threefoldtech/www-mastodon/issues/75
- https://github.com/threefoldtech/www-mastodon/issues/76

### Updates
- Support `context` while calling (**setValue**, **reset**, **validate**) in [tf-svelte-rx-forms](https://www.npmjs.com/package/tf-svelte-rx-forms) which allows us to pass custom errors
-  Add support for `context` in [tf-svelte-bulma-wc](https://www.npmjs.com/package/tf-svelte-bulma-wc) which allows us to user select with new *tf-svelte-rx-forms* feature.

- Add error handling for `farmId` shows error if no nodes within that farmID
![image](https://user-images.githubusercontent.com/31689104/206243348-44eac73c-73c7-4b28-8b76-af55f3ab127c.png)
![image](https://user-images.githubusercontent.com/31689104/206243369-c8569f58-c6ae-4d17-bad4-a3936f82a91c.png)

- Add error handling for `region` shows error if no nodes within that region
![image](https://user-images.githubusercontent.com/31689104/206243576-805e9d93-aed1-41af-a9c6-0c210fa80350.png)
![image](https://user-images.githubusercontent.com/31689104/206243617-840a8cc4-a611-487c-995d-ec2804e08648.png)

- Add error handling for `certified` shows error if no certified nodes
![image](https://user-images.githubusercontent.com/31689104/206243801-5dda05ee-b60f-4773-a67d-93bb5e3b4403.png)
![image](https://user-images.githubusercontent.com/31689104/206243873-ff4f2d31-9aa3-4fe6-a2b6-608ec34b36e6.png)

- Add error for `SelectNodeId` to check if node is up. (note: will trigger recheck whenever user click deploy)