### PR TITLE
Fix validating the smtp form when it's disabled

### DIFF
--- a/src/tabs/Advanced.svelte
+++ b/src/tabs/Advanced.svelte
@@ -5,7 +5,7 @@
   const { Input, CheckBox } = window.tfSvelteBulmaWc;
   import SelectNodeId from "../components/SelectNodeId.svelte";
   import SelectGateway from "../components/SelectGateway.svelte";
-  import { toggleSMTPRequired } from "../utils";
+  import { toggleSMTPRequired, smtpForm } from "../utils";
   import { onDestroy, onMount } from "svelte";
   import type { Unsubscriber } from "tf-svelte-rx-forms/dist/internals/rx_store";
 
@@ -17,18 +17,17 @@
   onMount(function mount() {
     if (!mastodon) requestAnimationFrame(mount);
     let __enable: boolean;
-    unsubscribe = mastodon
-      .get("smtp")
+    unsubscribe = smtpForm
       .get("enable")
       .subscribe((v) => {
         if (__enable === v.value) return;
         __enable = v.value;
-        toggleSMTPRequired(mastodon, __enable);
+        toggleSMTPRequired(smtpForm, __enable);
       });
   });
 
-  $: mastodon$ = $mastodon;
-  $: enableSmtp = mastodon$ ? mastodon$.value.smtp.value.enable.value : false;
+  $: smtp$ = $smtpForm;
+  $: enableSmtp = smtp$ ? smtp$.value.enable.value : false;
 </script>
 
 {#if mastodon}
@@ -84,7 +83,7 @@
       >
         <CheckBox
           label="<strong>SMTP Server</strong>"
-          controller={mastodon.get("smtp").get("enable")}
+          controller={smtpForm.get("enable")}
         />
       </b-tooltip>
     </div>
@@ -93,27 +92,27 @@
       <Input
         label="SMTP Email"
         placeholder="SMTP Email"
-        controller={mastodon.get("smtp").get("email")}
+        controller={smtpForm.get("email")}
       />
 
       <Input
         label="SMTP Password"
         placeholder="SMTP Password"
         type="password"
-        controller={mastodon.get("smtp").get("password")}
+        controller={smtpForm.get("password")}
       />
 
       <Input
         label="SMTP Server"
         placeholder="SMTP Server"
-        controller={mastodon.get("smtp").get("server")}
+        controller={smtpForm.get("server")}
       />
 
       <Input
         label="SMTP Port"
         placeholder="SMTP Port"
         type="number"
-        controller={mastodon.get("smtp").get("port")}
+        controller={smtpForm.get("port")}
       />
     {/if}
   </section>

--- a/src/utils/form.ts
+++ b/src/utils/form.ts
@@ -12,8 +12,6 @@ import {
 } from "./validators";
 
 const { fb, validators } = window.tfSvelteRxForms;
-const { GridClient } = window.grid3_client;
-const { HTTPMessageBusClient } = window.tsRmbHttpClient;
 
 export const noBalanceMessage = "Your balance is not enough.";
 export const mastodon = fb.group({
@@ -161,29 +159,29 @@ export const mastodon = fb.group({
     ],
   }),
 
-  smtp: fb.group({
-    enable: [false],
-    email: ["", [emailValidator]],
-    password: [
-      generateString(15),
-      [
-        validators.minLength("SMTP password must be at least 6 chars.", 6),
-        validators.maxLength("SMTP Password can't pass 15 chars.", 15),
-      ],
-    ],
-    server: [
-      "",
-      [validators.isURL("Invalid SMTP server.", { require_tld: true })],
-    ],
-    port: [null as number, [validators.isPort("Invalid SMTP port.")]],
-  }),
-
   region: [null as string, [getErrorFromCtx]],
 
   certified: [false, [getErrorFromCtx]],
 
   tfConnect: [false],
 });
+export const smtpForm = fb.group({
+  enable: [false],
+  email: ["", [emailValidator]],
+  password: [
+    generateString(15),
+    [
+      validators.minLength("SMTP password must be at least 6 chars.", 6),
+      validators.maxLength("SMTP Password can't pass 15 chars.", 15),
+    ],
+  ],
+  server: [
+    "",
+    [validators.isURL("Invalid SMTP server.", { require_tld: true })],
+  ],
+  port: [null as number, [validators.isPort("Invalid SMTP port.")]],
+})
+
 
 const mnemonics = mastodon.get("mnemonics");
 let unsub: Unsubscriber;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -31,17 +31,14 @@ const passwordReq = validators.required("SMTP Password is required.");
 const serverReq = validators.required("SMTP Server is required.");
 const portReq = validators.required("SMTP Port is required.");
 export function toggleSMTPRequired(
-  mastodon: FormGroup<{
     smtp: FormGroup<{
       email: FormControl<string>;
       password: FormControl<string>;
       server: FormControl<string>;
       port: FormControl<number>;
-    }>;
-  }>,
+    }>,
   required: boolean
 ) {
-  const smtp = mastodon.get("smtp");
   const email = smtp.get("email");
   const password = smtp.get("password");
   const server = smtp.get("server");


### PR DESCRIPTION
### Related Issues
- https://github.com/threefoldtech/www-mastodon/issues/159

if the SMTP is enabled and any field is filled you can not deploy even if you disabled it again

![image](https://user-images.githubusercontent.com/110984055/237012199-aed0bd75-0719-4ab2-9596-df1f774b4a2f.png)

now the form will be removed from the validation rule when the check box = false
