### PR TITLE
Update mastodon's flist to use an official threefold flist

### DIFF
--- a/src/Mastodon.svelte
+++ b/src/Mastodon.svelte
@@ -118,7 +118,7 @@
         ...mastodon.value,
         image: {
           flist:
-            "https://hub.grid.tf/omda.3bot/threefolddev-getmastodon-latest.flist",
+            "https://hub.grid.tf/tf-official-apps/mastodon-latest.flist",
           entryPoint: "/sbin/zinit init",
         },
         rootFsSize: 2,


### PR DESCRIPTION
### Description
Mastodon is currently using an official Threefold flist.

### Related Issues
- https://github.com/threefoldtech/www-mastodon/issues/150