### PR TITLE
Added the 'backendStorageType' attribute when initializing a new grid in creating an account.

### DIFF
--- a/src/tabs/Credentials.svelte
+++ b/src/tabs/Credentials.svelte
@@ -51,10 +51,10 @@
   async function onCreateAccount() {
     try {
       accountCreationStatus = "Creating";
-      const { GridClient } = window.grid3_client;
+      const { GridClient, BackendStorageType } = window.grid3_client;
 
       const network = window.config.network as NetworkEnv
-      const client = new GridClient({ mnemonic: "", network, storeSecret: "omda" });
+      const client = new GridClient({ mnemonic: "", network, storeSecret: "omda", backendStorageType: BackendStorageType.tfkvstore });
 
       client._connect();
 


### PR DESCRIPTION
### Description 
There was an issue with creating an account in the production mode, when building and serving the dest files, after some debugging we noticed that the issue happened because the grid client can't load the `local storage` file as seen in the first screen, the fix was about passing the `backendStorageType` to the grid when initializing a new instance 

![image](https://github.com/threefoldtech/www-mastodon/assets/57001890/5663fe29-f0c3-49b7-8064-fc690668790b)
![image](https://github.com/threefoldtech/www-mastodon/assets/57001890/bc3cc207-04bf-4b75-b066-f8bd6046cf29)

![image](https://github.com/threefoldtech/www-mastodon/assets/57001890/3fea3755-05c8-4afc-97f0-89a69ea6609e)

### Hint
this should be solved in the grid client, so what happened here was a workaround until the grid client get fixes 

### Related Issues
-  https://github.com/threefoldtech/www-mastodon/pull/171
